### PR TITLE
childモデルのnameとbirthdayにバリデーションをつける

### DIFF
--- a/app/models/child.rb
+++ b/app/models/child.rb
@@ -2,4 +2,12 @@
 
 class Child < ApplicationRecord
   has_one_attached :avatar
+
+  validates :name, presence: true
+  validates :birthday, presence: true
+  validate :birthday_before_today
+
+  def birthday_before_today
+    errors.add(:birthday, 'は今日以前の日付にしてください') if birthday > Date.current
+  end
 end

--- a/app/models/child.rb
+++ b/app/models/child.rb
@@ -8,6 +8,8 @@ class Child < ApplicationRecord
   validate :birthday_before_today
 
   def birthday_before_today
+    return unless birthday
+
     errors.add(:birthday, 'は今日以前の日付にしてください') if birthday > Date.current
   end
 end

--- a/app/views/children/_form.html.slim
+++ b/app/views/children/_form.html.slim
@@ -1,4 +1,11 @@
 = form_with(model: child) do |form|
+  - if child.errors.any?
+    div style=("color: red")
+      h2
+        - pluralize(child.errors.count, 'error')
+      ul
+        - child.errors.each do |error|
+          li = error.full_message
 
   div
     = form.label :name, style: 'display: block'

--- a/db/migrate/20220318125138_create_children.rb
+++ b/db/migrate/20220318125138_create_children.rb
@@ -1,8 +1,8 @@
 class CreateChildren < ActiveRecord::Migration[6.1]
   def change
     create_table :children do |t|
-      t.string :name
-      t.date :birthday
+      t.string :name, null:false
+      t.date :birthday, null:false
       t.references :user, foreign_key: true
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -44,18 +44,12 @@ ActiveRecord::Schema.define(version: 2022_03_23_065135) do
   end
 
   create_table "children", force: :cascade do |t|
-    t.string "name"
-    t.date "birthday"
+    t.string "name", null: false
+    t.date "birthday", null: false
     t.bigint "user_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["user_id"], name: "index_children_on_user_id"
-  end
-
-  create_table "template1", id: false, force: :cascade do |t|
-    t.integer "id"
-    t.text "name"
-    t.integer "age"
   end
 
   create_table "users", force: :cascade do |t|

--- a/test/system/children_test.rb
+++ b/test/system/children_test.rb
@@ -44,4 +44,23 @@ class Childrentest < ApplicationSystemTestCase
     assert_text '桃子'
     assert_text '2022年03月03日'
   end
+
+  test 'name_and_birthday_is_valid' do
+    setup
+    visit new_child_path
+    fill_in 'Name', with: nil
+    fill_in 'Birthday', with: nil
+    click_on '登録する'
+    assert_text 'Nameを入力してください'
+    assert_text 'Birthdayを入力してください'
+  end
+
+  test 'birthday_is_not_after_today' do
+    setup
+    visit new_child_path
+    fill_in 'Name', with: 'alice'
+    fill_in 'Birthday', with: Date.current + 1.day
+    click_on '登録する'
+    assert_text 'Birthdayは今日以前の日付にしてください'
+  end
 end


### PR DESCRIPTION
ref: #13 

## 変更点
- nameとbirthdayは入力必須とした
- birthdayは明日以降の日付をつけられないようにした
- それぞれバリデーションメッセージを追加した
- DB側にもNOT NULL制約を追加した