### PR TITLE
エラーメッセージの表示方法を変更

### DIFF
--- a/app/assets/stylesheets/histories.scss
+++ b/app/assets/stylesheets/histories.scss
@@ -1,9 +1,9 @@
-ul {
+.history__items {
   list-style: none;
 	padding-left: 0;
 }
 
-li {
+.history__item {
   float: left;
   width: 60px;
 	height: 40px;

--- a/app/views/children/_form.html.slim
+++ b/app/views/children/_form.html.slim
@@ -1,8 +1,6 @@
 = form_with(model: child) do |form|
   - if child.errors.any?
     div style=("color: red")
-      h2
-        - pluralize(child.errors.count, 'error')
       ul
         - child.errors.each do |error|
           li = error.full_message

--- a/app/views/histories/_form.html.slim
+++ b/app/views/histories/_form.html.slim
@@ -1,9 +1,6 @@
 = form_with(model: [child, history]) do |form|
   - if history.errors.any?
     div style=('color: red')
-      h2
-        = pluralize(history.errors.count, 'error')
-        | prohibited this history from being saved:
       ul
         - history.errors.each do |error|
           li = error.full_message

--- a/app/views/histories/index.html.slim
+++ b/app/views/histories/index.html.slim
@@ -11,7 +11,7 @@ table
         = vaccination_name
     tr
       td
-        ul class="vaccinated_table"
+        ul.history__items class="vaccinated_table"
           - vaccination_ids = Vaccination.where(name: vaccination_name).map(&:id)
           - case vaccination_ids.size
           - when 2..4
@@ -22,7 +22,7 @@ table
           - histories.each do |history|
             - default_number = ['①', '②', '③', '④']
             - vaccinated_number = ['❶', '❷', '❸', '❹']
-            li
+            li.history__item
               - if history.date || history.vaccinated
                 div class="vaccinated"
                   = link_to vaccinated_number[count], edit_child_history_path(params[:child_id], history.id)


### PR DESCRIPTION
#70 

## 変更点
別のページでクラス指定せずにulとliタグにCSSを適用させていたら全体に影響したため以下のように修正した
<img width="385" alt="スクリーンショット 2022-04-18 17 34 46" src="https://user-images.githubusercontent.com/82350582/163781910-20d25f37-2671-4f3c-9ffa-25235ca35737.png">
