### PR TITLE
/schedulesにて、今日以前が予防接種予定日のワクチンの表示方法を変更

### DIFF
--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -10,7 +10,6 @@ class Schedule < ApplicationRecord
       combined_name_and_date = sort_by_date_vaccination_days.each_with_object({}) do |day, ret|
         ret[day[:vaccinations]] = day[:date]
       end
-      # combined_name_and_date.each_key.group_by { |date| combined_name_and_date[date] }.each_value(&:sort!)
       combined_name_and_date.each_key.group_by { |date| combined_name_and_date[date] }.each_value { |ary| ary.sort_by { |hash| hash[:name] } }
     end
 

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -8,9 +8,10 @@ class Schedule < ApplicationRecord
           [Date, String].include?(day[:date].class) ? day[:date] : day[:date].first
         end
       combined_name_and_date = sort_by_date_vaccination_days.each_with_object({}) do |day, ret|
-        ret[day[:name]] = day[:date]
+        ret[day[:vaccinations]] = day[:date]
       end
-      combined_name_and_date.each_key.group_by { |date| combined_name_and_date[date] }.each_value(&:sort!)
+      # combined_name_and_date.each_key.group_by { |date| combined_name_and_date[date] }.each_value(&:sort!)
+      combined_name_and_date.each_key.group_by { |date| combined_name_and_date[date] }.each_value { |ary| ary.sort_by { |hash| hash[:name] } }
     end
 
     private
@@ -34,7 +35,7 @@ class Schedule < ApplicationRecord
                    calc_date(vaccination: vaccination, date: child.birthday, birthday: child.birthday)
                  end
                end
-        { name: "#{vaccination.name} #{vaccination.period}", date: date }
+        { vaccinations: { name: vaccination.name.to_s, period: vaccination.period.to_s }, date: date }
       end.compact
     end
 

--- a/app/views/schedules/index.html.slim
+++ b/app/views/schedules/index.html.slim
@@ -24,6 +24,4 @@ p
     ul.schedule__items
       - names.each do |name|
         li.schedule__item
-          - vaccination = Vaccination.find_by(name: name[:name], period: name[:period])
-          - history = History.find_by(vaccination_id: vaccination.id)
-          = link_to "#{name[:name]} #{name[:period]}", edit_child_history_path(@child, history.id)
+          = "#{name[:name]} #{name[:period]}"

--- a/app/views/schedules/index.html.slim
+++ b/app/views/schedules/index.html.slim
@@ -1,18 +1,29 @@
 = render '/children/child', child: @child
 
 p
-  - Schedule.future_plans(@histories, @child).each do |key, values|
-    br
-    - if key.instance_of?(Date)
-      = l(key, format: :long)
+  - Schedule.future_plans(@histories, @child).each do |date, names, idx|
+    - if (date.instance_of?(Range) && date.first <= Time.now) || (date.instance_of?(Date) && date <= Time.now)
+      = '現在接種可能' if idx == 0
+      ul.schedule__items
+        - names.each do |name|
+          li.schedule__item
+            - vaccination = Vaccination.find_by(name: name[:name], period: name[:period])
+            - history = History.find_by(vaccination_id: vaccination.id)
+            = link_to name[:name] + ' ' + name[:period], edit_child_history_path(@child, history.id)
+        - next
+
+    - if date.instance_of?(Date)
+      br
+      = l(date, format: :long)
     - else
+      br
       p 小学校入学前1年間
-      = l(key.first, format: :long)
-      br
-      ="〜#{l(key.last, format: :long)}"
-    br
+      = l(date.first, format: :long)
+      = "〜#{l(date.last, format: :long)}"
+
     ul.schedule__items
-      - values.each do |value|
+      - names.each do |name|
         li.schedule__item
-          = value
-      br
+          - vaccination = Vaccination.find_by(name: name[:name], period: name[:period])
+          - history = History.find_by(vaccination_id: vaccination.id)
+          = link_to name[:name] + ' ' + name[:period], edit_child_history_path(@child, history.id)

--- a/app/views/schedules/index.html.slim
+++ b/app/views/schedules/index.html.slim
@@ -2,14 +2,14 @@
 
 p
   - Schedule.future_plans(@histories, @child).each do |date, names, idx|
-    - if (date.instance_of?(Range) && date.first <= Time.now) || (date.instance_of?(Date) && date <= Time.now)
-      = '現在接種可能' if idx == 0
+    - if (date.instance_of?(Range) && date.first <= Time.current) || (date.instance_of?(Date) && date <= Time.current)
+      = '現在接種可能' if idx.zero?
       ul.schedule__items
         - names.each do |name|
           li.schedule__item
             - vaccination = Vaccination.find_by(name: name[:name], period: name[:period])
             - history = History.find_by(vaccination_id: vaccination.id)
-            = link_to name[:name] + ' ' + name[:period], edit_child_history_path(@child, history.id)
+            = link_to "#{name[:name]} #{name[:period]}", edit_child_history_path(@child, history.id)
         - next
 
     - if date.instance_of?(Date)
@@ -26,4 +26,4 @@ p
         li.schedule__item
           - vaccination = Vaccination.find_by(name: name[:name], period: name[:period])
           - history = History.find_by(vaccination_id: vaccination.id)
-          = link_to name[:name] + ' ' + name[:period], edit_child_history_path(@child, history.id)
+          = link_to "#{name[:name]} #{name[:period]}", edit_child_history_path(@child, history.id)

--- a/test/models/schedule_test.rb
+++ b/test/models/schedule_test.rb
@@ -6,8 +6,10 @@ class ScheduleTest < ActiveSupport::TestCase
   test 'future_plans' do
     carol = children(:carol)
     histories = History.where(child: carol)
-    expexted = { Date.parse('2022-03-03') => [{ name: 'ヒブ', period: '第1期' }, { name: 'ロタウイルス', period: '1回目' }], Date.parse('2022-04-03') => [{ name: 'ヒブ', period: '第2期' }, { name: 'ロタウイルス', period: '2回目' }],
-                 Date.parse('2022-05-03') => [{ name: 'ヒブ', period: '第3期' }, { name: 'ロタウイルス', period: '3回目' }], Date.parse('2023-01-03') => [{ name: 'ヒブ', period: '第4期' }] }
+    expexted = { Date.parse('2022-03-03') => [{ name: 'ヒブ', period: '第1期' }, { name: 'ロタウイルス', period: '1回目' }],
+                 Date.parse('2022-04-03') => [{ name: 'ヒブ', period: '第2期' }, { name: 'ロタウイルス', period: '2回目' }],
+                 Date.parse('2022-05-03') => [{ name: 'ヒブ', period: '第3期' }, { name: 'ロタウイルス', period: '3回目' }],
+                 Date.parse('2023-01-03') => [{ name: 'ヒブ', period: '第4期' }] }
     assert_equal expexted, Schedule.future_plans(histories, carol)
   end
 end

--- a/test/models/schedule_test.rb
+++ b/test/models/schedule_test.rb
@@ -6,8 +6,8 @@ class ScheduleTest < ActiveSupport::TestCase
   test 'future_plans' do
     carol = children(:carol)
     histories = History.where(child: carol)
-    expexted = { Date.parse('2022-03-03') => ['ヒブ 第1期', 'ロタウイルス 1回目'], Date.parse('2022-04-03') => ['ヒブ 第2期', 'ロタウイルス 2回目'],
-                 Date.parse('2022-05-03') => ['ヒブ 第3期', 'ロタウイルス 3回目'], Date.parse('2023-01-03') => ['ヒブ 第4期'] }
+    expexted = { Date.parse('2022-03-03') => [{ name: 'ヒブ', period: '第1期' }, { name: 'ロタウイルス', period: '1回目' }], Date.parse('2022-04-03') => [{ name: 'ヒブ', period: '第2期' }, { name: 'ロタウイルス', period: '2回目' }],
+                 Date.parse('2022-05-03') => [{ name: 'ヒブ', period: '第3期' }, { name: 'ロタウイルス', period: '3回目' }], Date.parse('2023-01-03') => [{ name: 'ヒブ', period: '第4期' }] }
     assert_equal expexted, Schedule.future_plans(histories, carol)
   end
 end


### PR DESCRIPTION
#74 

## 変更点
- 予防接種可能な日が今日以前の場合、「すでに打てるもの」として表示
- すでに打てるものは接種日の編集画面に飛べるようにリンクで表示