### PR TITLE
月齢計算のバグを修正

### DIFF
--- a/app/models/child.rb
+++ b/app/models/child.rb
@@ -14,4 +14,9 @@ class Child < ApplicationRecord
 
     errors.add(:birthday, 'は今日以前の日付にしてください') if birthday > Date.current
   end
+
+  def self.calc_moon_age(today, birthday)
+    moon_age = (today.year - birthday.year) * 12 + today.month - birthday.month - (today.day >= birthday.day ? 0 : 1)
+    "#{moon_age / 12}才 #{moon_age % 12}ヶ月"
+  end
 end

--- a/app/views/children/_child.html.slim
+++ b/app/views/children/_child.html.slim
@@ -9,7 +9,7 @@
           = child.name
       .name_age__items
         p
-          = "#{Time.zone.today.month - child.birthday.month}ヶ月"
+          = Child.calc_moon_age(Datr.current, child.birthday)
       .birthday__item
         p
           = "#{child.birthday.strftime('%Y年%m月%d日')}生まれ"

--- a/app/views/children/_child.html.slim
+++ b/app/views/children/_child.html.slim
@@ -9,7 +9,7 @@
           = child.name
       .name_age__items
         p
-          = Child.calc_moon_age(Datr.current, child.birthday)
+          = Child.calc_moon_age(Date.current, child.birthday)
       .birthday__item
         p
           = "#{child.birthday.strftime('%Y年%m月%d日')}生まれ"

--- a/test/models/child_test.rb
+++ b/test/models/child_test.rb
@@ -3,7 +3,21 @@
 require 'test_helper'
 
 class ChildTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test 'calc_moon_age birthday is same year' do
+    today = Date.parse('2022-04-22')
+    birthday = Date.parse('2022-01-01')
+    assert_equal '0才 3ヶ月', Child.calc_moon_age(today, birthday)
+  end
+
+  test 'calc_moon_age birthday is different year' do
+    today = Date.parse('2022-04-22')
+    birthday = Date.parse('2021-12-31')
+    assert_equal '0才 3ヶ月', Child.calc_moon_age(today, birthday)
+  end
+
+  test 'calc_moon_age birthday is different year and early month' do
+    today = Date.parse('2022-04-22')
+    birthday = Date.parse('2021-01-01')
+    assert_equal '1才 3ヶ月', Child.calc_moon_age(today, birthday)
+  end
 end


### PR DESCRIPTION
#89 

## 変更点
- 月齢計算に考慮漏れがあり、年度を跨ぐと月齢がマイナスになっていた＆計算が合わないバグを修正
- テストを追加