### PR TITLE
接種日のバリデーションを追加

### DIFF
--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -19,17 +19,18 @@ class History < ApplicationRecord
   def bigger_than_before_history
     return if date.nil?
 
-    vaccination = Vaccination.find(vaccination_id)
+    vaccination = History.find(id).vaccination
     last_letter = vaccination.key[-1]
     return if last_letter == '1'
 
-    before_vac_key = vaccination.key.gsub(/[2-4]/) { |num| (num.to_i - 1).to_s }
-    before_vac_id = Vaccination.find_by(key: before_vac_key).id
-    before_history = History.find_by(vaccination_id: before_vac_id, child_id: child.id)
+    vaccinations = Vaccination.where(name: vaccination.name).order(:id)
+    vaccinations.each do |vac|
+      next if vac.id < vaccination.id
 
-    return if before_history.date.nil?
-
-    errors.add(:date, 'が前回の期より前の日付になっています') if before_history.date > date
+      history = History.find_by(child_id: child, vaccination_id: vac.id)
+      next if history.date.nil?
+      return errors.add(:date, 'が前回の期より前の日付になっています') if history.date > date
+    end
   end
 
   def smaller_than_after_history

--- a/test/system/histories_test.rb
+++ b/test/system/histories_test.rb
@@ -71,6 +71,16 @@ class Historiestest < ApplicationSystemTestCase
     assert_text '接種日時が前回の期より前の日付になっています'
   end
 
+  test 'validation bigger than before before history' do
+    setup_alice
+    carol = children(:carol)
+    histories(:carol_history_rotavirus_first).update(date: Date.current - 2.months)
+    visit edit_child_history_path(carol.id, histories(:carol_history_rotavirus_third).id)
+    fill_in '接種日', with: Date.current - 2.months - 1.day
+    click_on '登録する'
+    assert_text '接種日時が前回の期より前の日付になっています'
+  end
+
   test 'validation not update bigger than before history' do
     setup_alice
     carol = children(:carol)
@@ -91,7 +101,17 @@ class Historiestest < ApplicationSystemTestCase
     assert_text '接種日時が次回の期より後の日付になっています'
   end
 
-  test 'validation not update smaller than before history' do
+  test 'validation smaller than before before history' do
+    setup_alice
+    carol = children(:carol)
+    histories(:carol_history_hib_force).update(date: Date.current - 1.month)
+    visit edit_child_history_path(carol.id, histories(:carol_history_hib_first).id)
+    fill_in '接種日', with: Date.current - 1.month + 1.day
+    click_on '登録する'
+    assert_text '接種日時が次回の期より後の日付になっています'
+  end
+
+  test 'validation update smaller than before history' do
     setup_alice
     carol = children(:carol)
     histories(:carol_history_rotavirus_third).update(date: Date.current - 1.month)


### PR DESCRIPTION
refs: 
- #69 

## 変更点
- 接種日が隣あう部分はバリデーションでカバーできていたが、隣り合わない場合が考慮されいなかったので修正した。
ex)  1回目と3回目、1回目と4回目も比較されるようにした。