### PR TITLE
.is-hoverableを削除したことにより子どもの編集ページへのリンクが出なくなったため修正

### DIFF
--- a/app/views/settings/_header.html.slim
+++ b/app/views/settings/_header.html.slim
@@ -20,7 +20,7 @@ nav class="navbar is-fixed-top" role="navigation" aria-label="main navigation"
 
         - if current_user.children.size >= 1
           hr class="dropdown-divider"
-          .navbar-item.has-dropdown
+          .navbar-item.has-dropdown.is-hoverable
             .navbar-item
               i class="fa-solid fa-children has-text-warning"
               .has-text-grey.navbar-text


### PR DESCRIPTION
refs: 
- #133 

## 変更点
- #140 
上記PRで`.is-hoverable`を削除した結果、ヘッダーからドロップダウンとリンクが出なくなったため修正した