### PR TITLE
子どもの情報を画面上部に固定

### DIFF
--- a/app/assets/stylesheets/_page-main.scss
+++ b/app/assets/stylesheets/_page-main.scss
@@ -2,6 +2,11 @@
   margin-top: 60px;
   margin-bottom: 60px;
 }
+
 body {
   background-color: #FFFFEF
+}
+
+.main__contents {
+  padding-top: 70px;
 }

--- a/app/assets/stylesheets/children.scss
+++ b/app/assets/stylesheets/children.scss
@@ -1,3 +1,11 @@
+.child_infos {
+  position: fixed;
+    z-index: 999;
+    top: 50px;
+    width: 100%;
+    background-color: #FFFFEF
+}
+
 .child__items {
   display: inline-block;
   text-align: center;

--- a/app/views/histories/edit.html.slim
+++ b/app/views/histories/edit.html.slim
@@ -1,5 +1,6 @@
 .page-main
   = render 'settings/header'
+  = render '/children/child', child: @child
   = render 'form', child: @child, history: @history, vaccination: @vaccination
   br/
 

--- a/app/views/histories/edit.html.slim
+++ b/app/views/histories/edit.html.slim
@@ -1,7 +1,8 @@
 .page-main
   = render 'settings/header'
   = render '/children/child', child: @child
-  = render 'form', child: @child, history: @history, vaccination: @vaccination
-  br/
+  .main__contents
+    = render 'form', child: @child, history: @history, vaccination: @vaccination
+    br/
 
   = render 'global_nav'

--- a/app/views/histories/index.html.slim
+++ b/app/views/histories/index.html.slim
@@ -5,54 +5,55 @@
       button class="delete"
       = notice
   = render '/children/child', child: @child
-  .card
-    .card-content
-      p.title.is-size-5.has-text-centered
-        | ワクチンの記録
-      p.subtitle.is-size-6.has-text-centered.pt-4
-        | 各ワクチンの直近の期数から
-        br/
-        | 日付を記録してください
-      p.subtitle.is-size-7.has-text-centered
-        i class="fa-solid fa-check"
-        | 入力した期以前は接種済みになります
-    table.table.is-striped
-      - count = 0
-      - vacs = []
-      - @vaccinations.each_with_index do |vaccination, idx|
-        tr
-          - if @vaccinations[idx].name != @vaccinations[idx - 1].name
-            - vacs = []
-            - vacs << vaccination
-            th.has-text-centered.table__items
-              - if Vaccination.regular?(vaccination.name)
-                .regular__item
-                  p.is-size-7 定期
-              - else
-                .voluntary__item
-                  p.is-size-7 任意
-              .pr-4
-                = vaccination.name
-              - count = 0
-          - else
-            - vacs << vaccination
-        - if (@vaccinations[idx] == @vaccinations[-1]) || (@vaccinations[idx.next].key[-1] == '1')
+  .main__contents
+    .card
+      .card-content
+        p.title.is-size-5.has-text-centered
+          | ワクチンの記録
+        p.subtitle.is-size-6.has-text-centered.pt-4
+          | 各ワクチンの直近の期数から
+          br/
+          | 日付を記録してください
+        p.subtitle.is-size-7.has-text-centered
+          i class="fa-solid fa-check"
+          | 入力した期以前は接種済みになります
+      table.table.is-striped
+        - count = 0
+        - vacs = []
+        - @vaccinations.each_with_index do |vaccination, idx|
           tr
-            td
-              ul.history__items
-                - vacs.each do |vac|
-                  li.history__item
-                    - history = History.find_by(vaccination_id: vac.id, child_id: @child)
-                    - if history && (history.date || history.vaccinated)
-                      .vaccinated_num
-                        - vaccinated_number = ['❶', '❷', '❸', '❹']
-                        = link_to vaccinated_number[count], edit_child_history_path(params[:child_id], history.id, vaccination_id: vac.id)
-                      .date.has-text-centered
-                          = history&.date&.strftime('%y/%m/%d')
-                    - else
-                      .non_vaccinated_num
-                        - default_number = ['①', '②', '③', '④']
-                        = link_to default_number[count], new_child_history_path(params[:child_id], vaccination_id: vac.id)
-                    - count += 1
+            - if @vaccinations[idx].name != @vaccinations[idx - 1].name
+              - vacs = []
+              - vacs << vaccination
+              th.has-text-centered.table__items
+                - if Vaccination.regular?(vaccination.name)
+                  .regular__item
+                    p.is-size-7 定期
+                - else
+                  .voluntary__item
+                    p.is-size-7 任意
+                .pr-4
+                  = vaccination.name
+                - count = 0
+            - else
+              - vacs << vaccination
+          - if (@vaccinations[idx] == @vaccinations[-1]) || (@vaccinations[idx.next].key[-1] == '1')
+            tr
+              td
+                ul.history__items
+                  - vacs.each do |vac|
+                    li.history__item
+                      - history = History.find_by(vaccination_id: vac.id, child_id: @child)
+                      - if history && (history.date || history.vaccinated)
+                        .vaccinated_num
+                          - vaccinated_number = ['❶', '❷', '❸', '❹']
+                          = link_to vaccinated_number[count], edit_child_history_path(params[:child_id], history.id, vaccination_id: vac.id)
+                        .date.has-text-centered
+                            = history&.date&.strftime('%y/%m/%d')
+                      - else
+                        .non_vaccinated_num
+                          - default_number = ['①', '②', '③', '④']
+                          = link_to default_number[count], new_child_history_path(params[:child_id], vaccination_id: vac.id)
+                      - count += 1
 
   = render 'global_nav'

--- a/app/views/histories/new.html.slim
+++ b/app/views/histories/new.html.slim
@@ -1,5 +1,6 @@
 .page-main
   = render 'settings/header'
+  = render '/children/child', child: @child
   = render 'form', child: @child, history: @history, vaccination: @vaccination
   br/
 

--- a/app/views/histories/new.html.slim
+++ b/app/views/histories/new.html.slim
@@ -1,7 +1,8 @@
 .page-main
   = render 'settings/header'
   = render '/children/child', child: @child
-  = render 'form', child: @child, history: @history, vaccination: @vaccination
-  br/
+  .main__contents
+    = render 'form', child: @child, history: @history, vaccination: @vaccination
+    br/
 
   = render 'global_nav'

--- a/app/views/histories/vaccinations/edit.html.slim
+++ b/app/views/histories/vaccinations/edit.html.slim
@@ -1,6 +1,0 @@
-.page-main
-  = render 'settings/header'
-  = render 'form', child: @child, vaccination: @vaccination, history: @history
-  br/
-
-  = render 'global_nav'

--- a/app/views/schedules/index.html.slim
+++ b/app/views/schedules/index.html.slim
@@ -2,10 +2,39 @@
   = render 'settings/header'
   = render '/children/child', child: @child
 
-  - Schedule.future_plans(@vaccinations, @child).each_with_index do |(date, names), index|
-    - if (date.instance_of?(Range) && date.first <= Time.current) || (date.instance_of?(Date) && date <= Time.current)
-      .has-text-centered
-        = '接種できるリスト' if index.zero?
+  .main__contents
+    - Schedule.future_plans(@vaccinations, @child).each_with_index do |(date, names), index|
+      - if (date.instance_of?(Range) && date.first <= Time.current) || (date.instance_of?(Date) && date <= Time.current)
+        .has-text-centered
+          = '接種できるリスト' if index.zero?
+        .card
+          .card-content
+            .content
+              - if date.instance_of?(Date)
+                .title.is-5.has-text-centered
+                  = l(date, format: :long)
+              - else
+                .title.is-5.has-text-centered
+                  p 小学校入学前1年間
+                .subtitle.is-7.has-text-centered
+                  = l(date.first, format: :default)
+                  = '〜'
+                  = l(date.last, format: :default)
+            ul.schedule__items
+              - names.each do |name|
+                li.is-inline-flex.pb-3
+                  .pr-3
+                    - if Vaccination.regular?(name[:name])
+                      .regular__item.is-size-7
+                        | 定期
+                    - else
+                      .voluntary__item.is-size-7
+                        | 任意
+                  - vaccination = Vaccination.find_by(name: name[:name], period: name[:period])
+                  = link_to "#{name[:name]} #{name[:period]}", new_child_history_path(@child, vaccination_id: vaccination.id)
+                br/
+        - next
+
       .card
         .card-content
           .content
@@ -19,6 +48,7 @@
                 = l(date.first, format: :default)
                 = '〜'
                 = l(date.last, format: :default)
+
           ul.schedule__items
             - names.each do |name|
               li.is-inline-flex.pb-3
@@ -29,36 +59,7 @@
                   - else
                     .voluntary__item.is-size-7
                       | 任意
-                - vaccination = Vaccination.find_by(name: name[:name], period: name[:period])
-                = link_to "#{name[:name]} #{name[:period]}", new_child_history_path(@child, vaccination_id: vaccination.id)
+                = "#{name[:name]} #{name[:period]}"
               br/
-      - next
-
-    .card
-      .card-content
-        .content
-          - if date.instance_of?(Date)
-            .title.is-5.has-text-centered
-              = l(date, format: :long)
-          - else
-            .title.is-5.has-text-centered
-              p 小学校入学前1年間
-            .subtitle.is-7.has-text-centered
-              = l(date.first, format: :default)
-              = '〜'
-              = l(date.last, format: :default)
-
-        ul.schedule__items
-          - names.each do |name|
-            li.is-inline-flex.pb-3
-              .pr-3
-                - if Vaccination.regular?(name[:name])
-                  .regular__item.is-size-7
-                    | 定期
-                - else
-                  .voluntary__item.is-size-7
-                    | 任意
-              = "#{name[:name]} #{name[:period]}"
-            br/
 
   = render 'global_nav'


### PR DESCRIPTION
refs:
- #133 

## 変更点
- /historyの新規登録や編集ページで誰の情報を編集しているのかわかりづらかったため子どもの情報を出すようにした
- 他のページにおいてもスクロールすると子の情報が隠れてしまうため画面上部に固定した