### PR TITLE
ドロップダウンと子どもの情報が被ってしまうため修正

### DIFF
--- a/app/assets/stylesheets/children.scss
+++ b/app/assets/stylesheets/children.scss
@@ -1,7 +1,6 @@
 .child_infos {
   position: fixed;
-    z-index: 999;
-    top: 50px;
+    top: 55px;
     width: 100%;
     background-color: #FFFFEF
 }


### PR DESCRIPTION
refs: 
- #133 
- #148 

## 変更点
ヘッダーのnavbarから出るドロップダウンと子どもの情報がかぶるため修正した