### PR TITLE
/schedulesと/familiesのデザインを変更

### DIFF
--- a/app/assets/stylesheets/families.scss
+++ b/app/assets/stylesheets/families.scss
@@ -42,9 +42,14 @@
 
 .families_child__picture {
   border-radius: 50%;
-  width: 30px;
-  height: 30px;
+  width: 40px;
+  height: 40px;
   object-fit: cover;
+  vertical-align: middle;
+}
+
+.families_child__name {
+  vertical-align: middle;
 }
 
 .subtitle.is-6.has-text-centered.pt-2 {

--- a/app/assets/stylesheets/families.scss
+++ b/app/assets/stylesheets/families.scss
@@ -46,3 +46,7 @@
   height: 30px;
   object-fit: cover;
 }
+
+.subtitle.is-6.has-text-centered.pt-2 {
+  color: #ff8206;
+}

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -22,7 +22,7 @@ class Schedule < ApplicationRecord
     end
 
     def how_many_more_days(date)
-      "あと#{date.day - Date.current.day}日" if date < (Date.current + 7.days)
+      "あと#{date.day - Date.current.day}日" if date <= (Date.current + 7.days)
     end
 
     private

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -13,6 +13,18 @@ class Schedule < ApplicationRecord
       combined_name_and_date.each_key.group_by { |date| combined_name_and_date[date] }.each_value { |ary| ary.sort_by! { |hash| hash[:name] } }
     end
 
+    def number_of_days_elapsed(start_day)
+      if TimeDifference.between(start_day, Date.current).in_days > 30
+        "#{TimeDifference.between(start_day, Date.current).in_months.floor}ヶ月経過"
+      else
+        "#{TimeDifference.between(start_day, Date.current).in_days.floor}日経過"
+      end
+    end
+
+    def how_many_more_days(date)
+      "接種日まであと#{date.day - Date.current.day}日です" if date < (Date.current + 7.days)
+    end
+
     private
 
     def new_schedules(vaccinations, child)

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -22,7 +22,7 @@ class Schedule < ApplicationRecord
     end
 
     def how_many_more_days(date)
-      "接種日まであと#{date.day - Date.current.day}日です" if date < (Date.current + 7.days)
+      "あと#{date.day - Date.current.day}日" if date < (Date.current + 7.days)
     end
 
     private

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -21,7 +21,7 @@ class Schedule < ApplicationRecord
       end
     end
 
-    def how_many_more_days(date)
+    def how_many_days_within_a_week(date)
       "あと#{date.day - Date.current.day}日" if date <= (Date.current + 7.days)
     end
 

--- a/app/views/families/index.html.slim
+++ b/app/views/families/index.html.slim
@@ -6,8 +6,8 @@ header
       button class="delete"
       = notice
   - Family.vaccination_date_before_today(@vaccinations, @children, Date.current).each_with_index do |(date, vacs), index|
-    .has-text-centered
-      = '現在接種できるもの' if index.zero?
+    .has-text-centered.is-size-6.has-text-weight-medium
+      = '予定日を過ぎています' if index.zero?
     - if (date.instance_of?(Range) && date.first <= Time.current) || (date.instance_of?(Date) && date <= Time.current)
       .card
         .card-content
@@ -27,21 +27,23 @@ header
                 =  Schedule.number_of_days_elapsed(date.first)
           - vacs.each_with_index do |vac, idx|
             - if idx.zero? || (idx != 0) && (vacs[idx][:child] != vacs[idx - 1][:child])
-              = image_tag vac[:child].avatar_url, class: 'families_child__picture'
-              = vac[:child].name
+              .pb-3
+                = image_tag vac[:child].avatar_url, class:'families_child__picture'
+                = vac[:child].name
             ul.schedule__items
               li.is-inline-flex.pb-3
                 .pr-3
                   - if Vaccination.regular?(vac[:name])
-                    .regular__item.is-size-7
-                      | 定期
+                    .regular__item
+                      p.is-size-7 定期
                   - else
-                    .voluntary__item.is-size-7
-                      | 任意
+                    .voluntary__item
+                      p.is-size-7 任意
                 = vac[:name]
+                = ' '
                 = vac[:period]
-  .has-text-centered
-    = 'まだ接種できないもの'
+  .has-text-centered.is-size-6.has-text-weight-medium
+    = 'まだ予定日になっていません'
   - Family.family_schedule(@vaccinations, @children).each_with_index do |(date, vaccinations), _index|
     - unless (date.instance_of?(Range) && date.first <= Time.current) || (date.instance_of?(Date) && date <= Time.current)
       .card
@@ -62,10 +64,11 @@ header
                 = Schedule.how_many_more_days(date.first)
           - vaccinations.each_with_index do |vac, idx|
             - if idx.zero? || idx != 0 && vaccinations[idx][:child] != vaccinations[idx - 1][:child]
-              = image_tag vac[:child].avatar_url, class: 'families_child__picture'
-              = vac[:child].name
+              .pb-3
+                = image_tag vac[:child].avatar_url, class: 'families_child__picture'
+                = vac[:child].name
             ul.schedule__items
-                li.is-inline-flex.pb-3
+                li.is-inline-flex.pb-2
                   .pr-3
                     - if Vaccination.regular?(vac[:name])
                       .regular__item
@@ -74,6 +77,7 @@ header
                       .voluntary__item
                         p.is-size-7 任意
                   = vac[:name]
+                  = ' '
                   = vac[:period]
 
   = render 'global_nav'

--- a/app/views/families/index.html.slim
+++ b/app/views/families/index.html.slim
@@ -53,7 +53,7 @@ header
               .title.is-5.has-text-centered
                 = l(date, format: :long)
               .subtitle.is-6.has-text-centered.pt-2
-                = Schedule.how_many_more_days(date)
+                = Schedule.how_many_days_within_a_week(date)
             - else
               .title.is-5.has-text-centered
                 = l(date.first, format: :long)
@@ -61,7 +61,7 @@ header
                 = '〜'
                 = l(date.last, format: :long)
               .subtitle.is-6.has-text-centered.pt-2
-                = Schedule.how_many_more_days(date.first)
+                = Schedule.how_many_days_within_a_week(date.first)
           - vaccinations.each_with_index do |vac, idx|
             - if idx.zero? || idx != 0 && vaccinations[idx][:child] != vaccinations[idx - 1][:child]
               .pb-3

--- a/app/views/families/index.html.slim
+++ b/app/views/families/index.html.slim
@@ -7,19 +7,24 @@ header
       = notice
   - Family.vaccination_date_before_today(@vaccinations, @children, Date.current).each_with_index do |(date, vacs), index|
     .has-text-centered
-      = '接種できるリスト' if index.zero?
+      = '現在接種できるもの' if index.zero?
     - if (date.instance_of?(Range) && date.first <= Time.current) || (date.instance_of?(Date) && date <= Time.current)
       .card
         .card-content
           .content
-            .title.is-5.has-text-centered
-              - if date.instance_of?(Date)
+            - if date.instance_of?(Date)
+              .title.is-5.has-text-centered
                 = l(date, format: :long)
-              - else
+              .subtitle.is-6.has-text-centered.has-text-danger.pt-2
+                = Schedule.number_of_days_elapsed(date)
+            - else
+              .title.is-5.has-text-centered
                 = l(date.first, format: :long)
                 = '〜'
                 br
                 = l(date.last, format: :long)
+              .subtitle.is-6.has-text-centered.has-text-danger.pt-2
+                =  Schedule.number_of_days_elapsed(date.first)
           - vacs.each_with_index do |vac, idx|
             - if idx.zero? || (idx != 0) && (vacs[idx][:child] != vacs[idx - 1][:child])
               = image_tag vac[:child].avatar_url, class: 'families_child__picture'
@@ -36,7 +41,7 @@ header
                 = vac[:name]
                 = vac[:period]
   .has-text-centered
-    = 'これからリスト'
+    = 'まだ接種できないもの'
   - Family.family_schedule(@vaccinations, @children).each_with_index do |(date, vaccinations), _index|
     - unless (date.instance_of?(Range) && date.first <= Time.current) || (date.instance_of?(Date) && date <= Time.current)
       .card
@@ -45,12 +50,16 @@ header
             - if date.instance_of?(Date)
               .title.is-5.has-text-centered
                 = l(date, format: :long)
+              .subtitle.is-6.has-text-centered.pt-2
+                = Schedule.how_many_more_days(date)
             - else
               .title.is-5.has-text-centered
                 = l(date.first, format: :long)
               .subtitle.is-7.has-text-centered
                 = '〜'
                 = l(date.last, format: :long)
+              .subtitle.is-6.has-text-centered.pt-2
+                = Schedule.how_many_more_days(date.first)
           - vaccinations.each_with_index do |vac, idx|
             - if idx.zero? || idx != 0 && vaccinations[idx][:child] != vaccinations[idx - 1][:child]
               = image_tag vac[:child].avatar_url, class: 'families_child__picture'

--- a/app/views/families/index.html.slim
+++ b/app/views/families/index.html.slim
@@ -28,7 +28,7 @@ header
           - vacs.each_with_index do |vac, idx|
             - if idx.zero? || (idx != 0) && (vacs[idx][:child] != vacs[idx - 1][:child])
               .pb-3
-                = image_tag vac[:child].avatar_url, class:'families_child__picture'
+                = image_tag vac[:child].avatar_url, class: 'families_child__picture'
                 = vac[:child].name
             ul.schedule__items
               li.is-inline-flex.pb-3

--- a/app/views/schedules/index.html.slim
+++ b/app/views/schedules/index.html.slim
@@ -3,11 +3,15 @@ header
   = render '/children/child', child: @child
 
 .page-main.main__contents
+  - if notice
+    .notification.is-success.is-light
+      button class="delete"
+      = notice
   - count = 0
   - Schedule.future_plans(@vaccinations, @child).each_with_index do |(date, names)|
     - if (date.instance_of?(Range) && date.first <= Date.current) || (date.instance_of?(Date) && date <= Date.current)
-      .has-text-centered
-        = '現在接種できるもの' if count.zero?
+      .has-text-centered.is-size-6.has-text-weight-medium
+        = '予定日を過ぎています' if count.zero?
         - count += 1
       .card
         .card-content
@@ -41,8 +45,8 @@ header
   - count = 0
   - Schedule.future_plans(@vaccinations, @child).each_with_index do |(date, names)|
     - if (date.instance_of?(Range) && date.first > Date.current) || (date.instance_of?(Date) && date > Date.current)
-      .has-text-centered
-        = 'まだ接種できないもの' if count.zero?
+      .has-text-centered.is-size-6.has-text-weight-medium
+        = 'まだ予定日になっていません' if count.zero?
       .card
         .card-content
           .content
@@ -71,7 +75,6 @@ header
                     .voluntary__item.is-size-7
                       | 任意
                 = "#{name[:name]} #{name[:period]}"
-              br/
       - count += 1
 
   = render 'global_nav'

--- a/app/views/schedules/index.html.slim
+++ b/app/views/schedules/index.html.slim
@@ -3,23 +3,28 @@ header
   = render '/children/child', child: @child
 
 .page-main.main__contents
-  - Schedule.future_plans(@vaccinations, @child).each_with_index do |(date, names), index|
-    - if (date.instance_of?(Range) && date.first <= Time.current) || (date.instance_of?(Date) && date <= Time.current)
+  - count = 0
+  - Schedule.future_plans(@vaccinations, @child).each_with_index do |(date, names)|
+    - if (date.instance_of?(Range) && date.first <= Date.current) || (date.instance_of?(Date) && date <= Date.current)
       .has-text-centered
-        = '接種できるリスト' if index.zero?
+        = '現在接種できるもの' if count.zero?
+        - count += 1
       .card
         .card-content
           .content
             - if date.instance_of?(Date)
               .title.is-5.has-text-centered
                 = l(date, format: :long)
+              .subtitle.is-6.has-text-centered.has-text-danger.pt-2
+                = Schedule.number_of_days_elapsed(date)
             - else
               .title.is-5.has-text-centered
                 p 小学校入学前1年間
-              .subtitle.is-7.has-text-centered
                 = l(date.first, format: :default)
                 = '〜'
                 = l(date.last, format: :default)
+              .subtitle.is-6.has-text-centered.has-text-danger.pt-2
+                =  Schedule.number_of_days_elapsed(date.first)
           ul.schedule__items
             - names.each do |name|
               li.is-inline-flex.pb-3
@@ -33,33 +38,40 @@ header
                 - vaccination = Vaccination.find_by(name: name[:name], period: name[:period])
                 = link_to "#{name[:name]} #{name[:period]}", new_child_history_path(@child, vaccination_id: vaccination.id)
               br/
-      - next
-
-    .card
-      .card-content
-        .content
-          - if date.instance_of?(Date)
-            .title.is-5.has-text-centered
-              = l(date, format: :long)
-          - else
-            .title.is-5.has-text-centered
-              p 小学校入学前1年間
-            .subtitle.is-7.has-text-centered
-              = l(date.first, format: :default)
-              = '〜'
-              = l(date.last, format: :default)
-
-        ul.schedule__items
-          - names.each do |name|
-            li.is-inline-flex.pb-3
-              .pr-3
-                - if Vaccination.regular?(name[:name])
-                  .regular__item.is-size-7
-                    | 定期
-                - else
-                  .voluntary__item.is-size-7
-                    | 任意
-              = "#{name[:name]} #{name[:period]}"
-            br/
+  - count = 0
+  - Schedule.future_plans(@vaccinations, @child).each_with_index do |(date, names)|
+    - if (date.instance_of?(Range) && date.first > Date.current) || (date.instance_of?(Date) && date > Date.current)
+      .has-text-centered
+        = 'まだ接種できないもの' if count.zero?
+      .card
+        .card-content
+          .content
+            - if date.instance_of?(Date)
+              .title.is-5.has-text-centered
+                = l(date, format: :long)
+              .subtitle.is-6.has-text-centered.pt-2
+                =  Schedule.how_many_more_days(date)
+            - else
+              .title.is-5.has-text-centered
+                p 小学校入学前1年間
+              .subtitle.is-7.has-text-centered
+                = l(date.first, format: :default)
+                = '〜'
+                = l(date.last, format: :default)
+              .subtitle.is-6.has-text-centered.pt-2
+                =  Schedule.how_many_more_days(date.first)
+          ul.schedule__items
+            - names.each do |name|
+              li.is-inline-flex.pb-3
+                .pr-3
+                  - if Vaccination.regular?(name[:name])
+                    .regular__item.is-size-7
+                      | 定期
+                  - else
+                    .voluntary__item.is-size-7
+                      | 任意
+                = "#{name[:name]} #{name[:period]}"
+              br/
+      - count += 1
 
   = render 'global_nav'

--- a/app/views/schedules/index.html.slim
+++ b/app/views/schedules/index.html.slim
@@ -54,7 +54,7 @@ header
               .title.is-5.has-text-centered
                 = l(date, format: :long)
               .subtitle.is-6.has-text-centered.pt-2
-                =  Schedule.how_many_more_days(date)
+                =  Schedule.how_many_days_within_a_week(date)
             - else
               .title.is-5.has-text-centered
                 p 小学校入学前1年間
@@ -63,7 +63,7 @@ header
                 = '〜'
                 = l(date.last, format: :default)
               .subtitle.is-6.has-text-centered.pt-2
-                =  Schedule.how_many_more_days(date.first)
+                =  Schedule.how_many_days_within_a_week(date.first)
           ul.schedule__items
             - names.each do |name|
               li.is-inline-flex.pb-3

--- a/test/models/schedule_test.rb
+++ b/test/models/schedule_test.rb
@@ -89,4 +89,24 @@ class ScheduleTest < ActiveSupport::TestCase
                  Date.parse('2032-07-21') => [{ name: '２種混合', period: '1回目', child: dave }] }
     assert_equal expected, Schedule.future_plans(vaccinations, dave)
   end
+
+  test 'number_of_days_elapsed when months' do
+    start_day = Date.current + 31.days
+    assert_equal '1ヶ月経過', Schedule.number_of_days_elapsed(start_day)
+  end
+
+  test 'number_of_days_elapsed when days' do
+    start_day = Date.current + 30.days
+    assert_equal '30日経過', Schedule.number_of_days_elapsed(start_day)
+  end
+
+  test 'how_many_more_days within one week' do
+    date = Date.current + 7.days
+    assert_equal 'あと7日', Schedule.how_many_more_days(date)
+  end
+
+  test 'how_many_more_days not within one week' do
+    date = Date.current + 8.days
+    assert_nil Schedule.how_many_more_days(date)
+  end
 end

--- a/test/models/schedule_test.rb
+++ b/test/models/schedule_test.rb
@@ -102,11 +102,11 @@ class ScheduleTest < ActiveSupport::TestCase
 
   test 'how_many_more_days within one week' do
     date = Date.current + 7.days
-    assert_equal 'あと7日', Schedule.how_many_more_days(date)
+    assert_equal 'あと7日', Schedule.how_many_days_within_a_week(date)
   end
 
   test 'how_many_more_days not within one week' do
     date = Date.current + 8.days
-    assert_nil Schedule.how_many_more_days(date)
+    assert_nil Schedule.how_many_days_within_a_week(date)
   end
 end

--- a/test/system/top_test.rb
+++ b/test/system/top_test.rb
@@ -49,7 +49,7 @@ class Toptest < ApplicationSystemTestCase
   test 'redirect to families_path when login and user has many child' do
     setup_bob
     visit '/'
-    assert_text '接種できるリスト'
+    assert_text '予定日を過ぎています'
     assert_no_text 'ログイン'
   end
 end


### PR DESCRIPTION
refs:
- #135 

## 変更点
- 昨日の自作サービス進捗報告会で上記ページのデザインについて相談したところ、Issue内にあることをアドバイスいただいたのでその部分を修正
- 文字の大きさや間隔を修正
- 追加したメソッドや変更した文言に対応するテストを修正