### PR TITLE
接種履歴の新規作成画面で、接種推奨日を予め表示させる

### DIFF
--- a/app/controllers/histories_controller.rb
+++ b/app/controllers/histories_controller.rb
@@ -5,7 +5,8 @@ class HistoriesController < ApplicationController
   before_action :set_vaccination, only: %i[new edit create update]
 
   def new
-    @history = @child.histories.new
+    date = Schedule.next_plan(@vaccination, @child)
+    @history = @child.histories.new(date: [Date, String].include?(date.class) ? date : date.first)
     @history.vaccination_id = @vaccination.id
   end
 

--- a/app/views/histories/_form.html.slim
+++ b/app/views/histories/_form.html.slim
@@ -12,7 +12,12 @@
         = @vaccination.period
       .mt-3
         = form.label :date, '接種日'
-        = form.date_field :date, class: 'input'
+        .mt-1
+          = form.date_field :date, class: 'input'
+      - if current_page?(new_child_history_path(child))
+          .is-size-7.mt-1
+            i class="fa-solid fa-pen"
+            | 自動計算した接種予定日を表示しています
       .has-text-centered.mt-5
         button class="button color" type="submit"
           .has-text-white

--- a/test/models/schedule_test.rb
+++ b/test/models/schedule_test.rb
@@ -109,4 +109,18 @@ class ScheduleTest < ActiveSupport::TestCase
     date = Date.current + 8.days
     assert_nil Schedule.how_many_days_within_a_week(date)
   end
+
+  test 'next_plan when before history nil' do
+    child = children(:dave)
+    vaccination = 'hib_2'
+    hib_second = vaccinations(:"#{vaccination}")
+    assert_equal Date.parse('2021-10-21'), Schedule.next_plan(hib_second, child)
+  end
+
+  test 'next_plan when before history exists' do
+    child = children(:eve)
+    rota_third = 'rotavirus_3'
+    vaccination = vaccinations(:"#{rota_third}")
+    assert_equal Date.parse('2022-03-29'), Schedule.next_plan(vaccination, child)
+  end
 end

--- a/test/system/histories_test.rb
+++ b/test/system/histories_test.rb
@@ -177,21 +177,10 @@ class Historiestest < ApplicationSystemTestCase
     eve = children(:eve)
     histories(:eve_history_rotavirus_third).update(date: Date.current - 1.month)
 
-    vaccination_key = 'rotavirus_2'
+    vaccination_key = 'rotavirus_3'
     visit new_child_history_path(eve.id, vaccination_id: vaccinations(:"#{vaccination_key}"))
     fill_in '接種日', with: Date.current - 1.month - 1.day
     click_on '登録する'
     assert_text 'Vaccinationはすでに存在します'
-  end
-
-  test 'validation history not date and vaccinated' do
-    setup_alice
-    eve = children(:eve)
-    histories(:eve_history_rotavirus_third).update(date: Date.current - 1.month)
-
-    vaccination_key = 'rotavirus_3'
-    visit new_child_history_path(eve.id, vaccination_id: vaccinations(:"#{vaccination_key}"))
-    click_on '登録する'
-    assert_text '接種日時が入力されていません'
   end
 end


### PR DESCRIPTION
- #184 

新規作成の負担を減らすために接種推奨日を`/children/:child_id/histories/new`で予め表示させた